### PR TITLE
M401A frequency adaptation

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-g12a-s905l3a-m401a.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-g12a-s905l3a-m401a.dts
@@ -31,31 +31,29 @@
 
 		power_led {
 			led_name = "power_led";
-					gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_LOW>;
 			default-state = "on";
 		};
 
 		net_led {
 			led_name = "net_led";
-					gpios = <&gpio_ao GPIOAO_9 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio_ao GPIOAO_9 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 			linux,default-trigger = "0.0:00:link";
 		};
 
 		remote_led {
 			led_name = "remote_led";
-					gpios = <&gpio_ao GPIOAO_10 GPIO_ACTIVE_LOW>;
+			gpios = <&gpio_ao GPIOAO_10 GPIO_ACTIVE_LOW>;
 			default-state = "off";
 			linux,default-trigger = "rc-feedback";
 		};
-
 	};
 
 	memory@0 {
 		device_type = "memory";
 		reg = <0x0 0x0 0x0 0x80000000>;
 	};
-
 };
 
 &uart_A {
@@ -91,20 +89,67 @@
 /* CPU Overclock */
 &cpu_opp_table {
 	opp-100000000 {
-		status = "disabled";
+		opp-hz = /bits/ 64 <100000000>;
+		opp-microvolt = <731000>;
 	};
 
 	opp-250000000 {
-		status = "disabled";
+		opp-hz = /bits/ 64 <250000000>;
+		opp-microvolt = <731000>;
 	};
 	
 	opp-500000000 {
-		status = "disabled";
+		opp-hz = /bits/ 64 <500000000>;
+		opp-microvolt = <731000>;
 	};
 
 	opp-667000000 {
+		opp-hz = /bits/ 64 <667000000>;
+		opp-microvolt = <731000>;
+	};
+	
+	opp-1000000000 {
+		opp-hz = /bits/ 64 <1000000000>;
+		opp-microvolt = <731000>;
+	};
+
+	opp-1200000000 {
+		opp-hz = /bits/ 64 <1200000000>;
+		//opp-microvolt = <731000>;
+		opp-microvolt = <761000>;
+	};
+
+	opp-1398000000 {
+		opp-hz = /bits/ 64 <1398000000>;
+		//opp-microvolt = <761000>;
+		opp-microvolt = <791000>;
+	};
+
+	opp-1512000000 {
+		opp-hz = /bits/ 64 <1512000000>;
+		//opp-microvolt = <791000>;
+		opp-microvolt = <831000>;
+	};
+
+	opp-1608000000 {
+		opp-hz = /bits/ 64 <1608000000>;
+		//opp-microvolt = <831000>;
+		opp-microvolt = <871000>;
+	};
+
+	opp-1704000000 {
+		opp-hz = /bits/ 64 <1704000000>;
+		//opp-microvolt = <861000>;
+		opp-microvolt = <921000>;
+	};
+	
+	/* some soc has crash under 1800 */
+	opp-1800000000 {
+		opp-hz = /bits/ 64 <1800000000>;
+		opp-microvolt = <981000>;
 		status = "disabled";
 	};
+		
 };
 
 &internal_ephy  {


### PR DESCRIPTION
M401A frequency adaptation

1. Use the official firmware frequency configuration
2. Reduce frequency to improve adaptability