### PR TITLE
Support for HK1 BOX system led (not LED display)

### DIFF
--- a/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
+++ b/arch/arm64/boot/dts/amlogic/meson-sm1-hk1box-vontar-x3.dts
@@ -83,6 +83,17 @@
 		dev_name = "openvfd";
 		status = "okay";
 	};
+
+	leds {
+		compatible = "gpio-leds";
+		status = "okay";
+		sys_led {
+			label = "sys_led";
+			gpios = <&gpio_ao GPIOAO_11 GPIO_ACTIVE_HIGH>;
+			default-state = "on";
+			linux,default-trigger = "default-on";
+		};
+	};
 };
 
 &vddcpu {


### PR DESCRIPTION
为HK1 Box 的蓝色系统指示灯（非LED显示屏）添加支持